### PR TITLE
PyTorch >= 1.3 compatible code

### DIFF
--- a/siam_tracker/ops/crop_and_resize/function.py
+++ b/siam_tracker/ops/crop_and_resize/function.py
@@ -7,37 +7,28 @@ from . import crop_and_resize as _B
 
 
 class CropAndResizeFunction(Function):
-
-    def __init__(self, crop_height, crop_width, extrapolation_value=0.0, has_normed=False):
-        """ Torch Function for crop and resize (bilinear) implementation
-        Args:
-            crop_height: the output height, int
-            crop_width: the output width, int
-            extrapolation_value: paddding value for some pixel outside the source input, 0.0 by default
-            has_normed: if the input coordinate is normalized by image size (height & width).
-        """
-        self.crop_height = crop_height
-        self.crop_width = crop_width
-        self.extrapolation_value = extrapolation_value
-        self.has_normed = has_normed
-
+    """ Torch Function for crop and resize (bilinear) implementation"""
     @staticmethod
-    def forward(self, image, boxes, box_inds):
+    def forward(ctx, image, boxes, box_inds, crop_height, crop_width, extrapolation_value, has_normed):
         """
         Args:
             image: torch.Tensor of shape [N, C, H, W], 4 dimention is supported only.
             boxes: torch.Tensor of shape [K, 4], the cropping box coordinates, in order of [x1, y1, x2, y2]
             box_inds: torch.Tensor of shape [K, 1], the index indicates which image to crop.
+            crop_height: the output height, int
+            crop_width: the output width, int
+            extrapolation_value: paddding value for some pixel outside the source input, 0.0 by default
+            has_normed: if the input coordinate is normalized by image size (height & width).
         """
         box_inds = box_inds.contiguous()
         crop_boxes = boxes[:, :4].contiguous()
 
         n, c, h, w = image.size()
-        self.batch_size = int(n)
-        self.image_height = int(h)
-        self.image_width = int(w)
+        batch_size = int(n)
+        image_height = int(h)
+        image_width = int(w)
 
-        if not self.has_normed:
+        if not has_normed:
             # normalization if necessary
             crop_boxes[:, 0:4:2] /= (w - 1)
             crop_boxes[:, 1:4:2] /= (h - 1)
@@ -46,25 +37,25 @@ class CropAndResizeFunction(Function):
             # if image is on GPU device. We should crop it in the same device.
             with torch.cuda.device(image.device.index):
                 crops = _B.forward(image, crop_boxes, box_inds,
-                                   self.extrapolation_value, self.crop_height, self.crop_width)
+                                   extrapolation_value, crop_height, crop_width)
         else:
             crops = _B.forward(image, crop_boxes, box_inds,
-                               self.extrapolation_value, self.crop_height, self.crop_width)
+                               extrapolation_value, crop_height, crop_width)
 
         # save for backward
-        self.save_for_backward(crop_boxes, box_inds)
+        ctx.save_for_backward(crop_boxes, box_inds, batch_size, image_height, image_width)
 
         return crops
 
     @staticmethod
-    def backward(self, grad_outputs):
-        boxes, box_ind = self.saved_tensors
+    def backward(ctx, grad_outputs):
+        boxes, box_ind, batch_size, image_height, image_width = ctx.saved_tensors
         grad_outputs = grad_outputs.contiguous()
         if grad_outputs.is_cuda:
             with torch.cuda.device(grad_outputs.device.index):
                 grads_image = _B.backward(grad_outputs, boxes, box_ind,
-                                          self.batch_size, self.image_height, self.image_width)
+                                          batch_size, image_height, image_width)
         else:
             grads_image = _B.backward(grad_outputs, boxes, box_ind,
-                                      self.batch_size, self.image_height, self.image_width)
+                                      batch_size, image_height, image_width)
         return grads_image, None, None

--- a/siam_tracker/ops/crop_and_resize/function.py
+++ b/siam_tracker/ops/crop_and_resize/function.py
@@ -21,6 +21,7 @@ class CropAndResizeFunction(Function):
         self.extrapolation_value = extrapolation_value
         self.has_normed = has_normed
 
+    @staticmethod
     def forward(self, image, boxes, box_inds):
         """
         Args:
@@ -55,6 +56,7 @@ class CropAndResizeFunction(Function):
 
         return crops
 
+    @staticmethod
     def backward(self, grad_outputs):
         boxes, box_ind = self.saved_tensors
         grad_outputs = grad_outputs.contiguous()

--- a/siam_tracker/spm_tracker/modules/spm_tracker_fm.py
+++ b/siam_tracker/spm_tracker/modules/spm_tracker_fm.py
@@ -48,7 +48,7 @@ class FeatExtractor(torch.nn.Module):
                 i_feat = feats[feat_name]
 
             i_roi_boxes = roi_boxes / self.stride_list[ix]
-            i_roi_feat = CropAndResizeFunction(self.out_height, self.out_width, has_normed=False)(
+            i_roi_feat = CropAndResizeFunction.apply(self.out_height, self.out_width, has_normed=False)(
                 i_feat, i_roi_boxes, roi_inds)
             roi_feats.append(i_roi_feat)
 

--- a/siam_tracker/spm_tracker/modules/spm_tracker_fm.py
+++ b/siam_tracker/spm_tracker/modules/spm_tracker_fm.py
@@ -48,8 +48,8 @@ class FeatExtractor(torch.nn.Module):
                 i_feat = feats[feat_name]
 
             i_roi_boxes = roi_boxes / self.stride_list[ix]
-            i_roi_feat = CropAndResizeFunction.apply(self.out_height, self.out_width, has_normed=False)(
-                i_feat, i_roi_boxes, roi_inds)
+            i_roi_feat = CropAndResizeFunction.apply(
+                i_feat, i_roi_boxes, roi_inds, self.out_height, self.out_width, 0.0, False)
             roi_feats.append(i_roi_feat)
 
         roi_feats = torch.cat(roi_feats, dim=1)

--- a/siam_tracker/utils/crop.py
+++ b/siam_tracker/utils/crop.py
@@ -75,8 +75,8 @@ def crop_with_boxes(img_tensor, x_crop_boxes, out_height, out_width, crop_inds=N
         img_tensor_minus_avg = img_tensor - img_channel_avg  # minus mean values
     else:
         img_tensor_minus_avg = img_tensor
-    crop_img_tensor = CropAndResizeFunction.apply(out_height, out_width, has_normed=has_normed_coords)(
-        img_tensor_minus_avg, crop_boxes, crop_inds)
+    crop_img_tensor = CropAndResizeFunction.apply(
+        img_tensor_minus_avg, crop_boxes, crop_inds, out_height, out_width, 0.0, has_normed_coords)
 
     if avg_channels:
         # add mean value

--- a/siam_tracker/utils/crop.py
+++ b/siam_tracker/utils/crop.py
@@ -75,7 +75,7 @@ def crop_with_boxes(img_tensor, x_crop_boxes, out_height, out_width, crop_inds=N
         img_tensor_minus_avg = img_tensor - img_channel_avg  # minus mean values
     else:
         img_tensor_minus_avg = img_tensor
-    crop_img_tensor = CropAndResizeFunction(out_height, out_width, has_normed=has_normed_coords)(
+    crop_img_tensor = CropAndResizeFunction.apply(out_height, out_width, has_normed=has_normed_coords)(
         img_tensor_minus_avg, crop_boxes, crop_inds)
 
     if avg_channels:


### PR DESCRIPTION
If you use old autograd function style in PyTorch >= 1.3, you get the following error:
"Legacy autograd function with non-static forward method is deprecated."

By properly edit CropAndResizeFunction function,
It also becomes available in PyTorch >= 1.3.